### PR TITLE
aps-140 Add webb support for React.js

### DIFF
--- a/APS-Webs/APSWebManager/README.md
+++ b/APS-Webs/APSWebManager/README.md
@@ -14,4 +14,6 @@ These components can be used as any React components, but all gui specific prope
 
 There is a component actually called `APSWebManager`, if this is used it is the only component needed under `<App>`. This component listens on the bus for a JSON gui spec and renders the components in this spec within itself. Each component will be connected to the bus, and JSON spec includes routing properties. As a common feature of APSComponent base component every component can act as a collector which listens to other components and saves their latest published data. Any event sent by a collector includes the collected data. If such a component is routed to the backend it will basically serve as a submit component. This does not require a form!
 
+Do **note** that there is absolutely no security what so ever yet!
+
 The frontend code is [here](src/main/js/aps-webmanager-frontend).

--- a/APS-Webs/APSWebManager/buildInfo.json
+++ b/APS-Webs/APSWebManager/buildInfo.json
@@ -1,3 +1,3 @@
 {
-    "buildNumber": 527
+    "buildNumber": 542
 }

--- a/APS-Webs/APSWebManager/docs/src/WebManager.md
+++ b/APS-Webs/APSWebManager/docs/src/WebManager.md
@@ -8,15 +8,15 @@ All components has a listenTo and a sendTo property which points out and address
 
 This separation of component rendering code and event handler code makes it rather easy to render components after a JSON specification. That is what WebManager does. It listens for a JSON GUI spec on the bus, and when it sees such, it renders it. When a user interacts with the rendered GUI messges will be sent on the bus.  
 
-## Bus
+## APSEventBus
 
-On the frontend there is a local `LocalEventBus` that is used to send and receive messages. This is basically a wrapper. It does not do anything other than pass on to 'EventBusRouter's. There are 2 'EventBusRouter's: `LocalEventBusRouter`and `VertxEventBusRouter`. These are both added to `LocalEventBus`. 
+On the frontend there is a local `APSEventBus` that is used to send and receive messages. This is basically a wrapper. It does not do anything other than pass on to 'EventBusRouter's. There are 2 'EventBusRouter's: `APSLocalEventBusRouter`and `APSVertxEventBusRouter`. These are both added to `APSEventBus`. 
 
-### LocalEventBusRouter
+### APSLocalEventBusRouter
 
 This looks at the header of a message and if _routing_ contains _client_ then it passes the message to all registered local subscribers. This never goes out on the network, it only works internatlly in the client. This is used to communicate between different components locally.
 
-### VertxEventBusRouter
+### APSVertxEventBusRouter
 
 This looks at the header of a message and if _routing_ contains _backend_ it does a send on the Vert.x client event bus bridge. A send does a round robin to to listeners of specified address. If _routing_ contains _cluster_ it does a publish on the Vert.x client event bus bridge. This goes to all listeners of the address in the whole cluster, including other clients.
 
@@ -34,7 +34,7 @@ As said above when a send is done on the Vert.x event bus it does a round robin 
 
 Note: (app) refers to a specific application as a wildcard, and (UUID) refers to a generated UUID value.
 
-From client perspective:
+From **client perspective**:
 
 - Client 
 
@@ -90,12 +90,20 @@ In the following specification any entry starting with '?' is optional.
 #### General
 
     {
-        "aps": {
+        "aps": { // To be moved to header instead ...
             "origin": "(address)",
             "app": "(app)",
-            "type": "(message type)"
+            "type": "(message type)",
+            "identity": {
+                userId: "(id)",
+                userName: "(name of user)",
+                auth: {
+                    "type": "(authentication type)",
+                    (authentication specific data)
+                }
+            }
         },
-        content: {
+        content: { // Will probably go away when "aps" is moved to header.
             ...message type specific data
         }
     }

--- a/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/APSVertxEventBusRouter.js
+++ b/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/APSVertxEventBusRouter.js
@@ -173,11 +173,12 @@ export default class APSVertxEventBusRouter implements APSEventBusRouter {
         catch ( error ) {
 
             this.tries = this.tries + 1;
-            if ( this.tries <= 5 ) {
+            if ( this.tries <= 1 ) {
                 this.re_startBus();
                 message( headers, message );
             }
             else {
+                if (this.tries <= 3)
                 throw new Error( `Vert.x eventbus has failed: ${error}` )
             }
         }

--- a/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/components/APSComponent.jsx
+++ b/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/components/APSComponent.jsx
@@ -246,7 +246,11 @@ class APSComponent extends Component {
     // noinspection JSMethodCanBeStatic
     messageHandler( message: { aps: { /*...*/ }, content: { /*...*/ } } ) {
 
-        this.logger.debug( `messageHandler > Received: ${JSON.stringify(message)}` );
+        try {
+            this.logger.debug( `messageHandler > Received: ${JSON.stringify( message )}` );
+        } catch ( e ) {
+            this.logger.error(`Failed logging: ${e}`);
+        }
 
         // If this component wants to collect values sent by other components, we
         // just save the whole message under 'collected' and using the components id as key.

--- a/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/components/APSDate.jsx
+++ b/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/components/APSDate.jsx
@@ -37,10 +37,9 @@ export default class APSDate extends APSComponent {
         return "aps-date";
     }
 
-    valueChangedHandler( date: string ) {
-        this.logger.debug( "Selected date: " + date );
+    valueChangedHandlerComputer( date: string ) {
 
-        if ( typeof date !== "undefined" && date !== null ) {
+        if ( date ) {
             this.empty = false;
             this.setState( {
                 value: date,
@@ -62,10 +61,37 @@ export default class APSDate extends APSComponent {
         }
     }
 
+    valueChangedHandlerMobile( event : {} ) {
+
+        if ( event ) {
+
+            this.empty = false;
+            this.setState( {
+                value: event.target.value,
+                disabled: this.state.disabled
+                // showPopover: false
+            } );
+
+            this.message(
+                this.changeEvent(
+                    {
+                        componentType: this.componentType(),
+                        value: event.target.value
+                    }
+                )
+            );
+        }
+        else {
+            this.empty = true;
+        }
+    }
+
     render() {
+
         if ( isMobileDevice().any() ) {
-            return <input id={this.props.guiProps.id} type={"date"} className={"form-control"} placeholder={"YYYY-MM-DD"}
-                          onChange={this.valueChangedHandler.bind( this )}/>
+            return <input id={this.props.guiProps.id} type={"date"} className={"form-control"}
+                          placeholder={"YYYY-MM-DD"}
+                          onChange={this.valueChangedHandlerMobile.bind( this )}/>
         }
         else {
             return <DayPickerInput
@@ -85,7 +111,7 @@ export default class APSDate extends APSComponent {
                 // This is needed to play nice with the Bootstrap L&F.
                 component={props => <input className="form-control" {...props} />}
 
-                onDayChange={this.valueChangedHandler.bind( this )}
+                onDayChange={this.valueChangedHandlerComputer.bind( this )}
 
                 disabled={this.state.disabled}
             />

--- a/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/components/APSWebManager.jsx
+++ b/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/components/APSWebManager.jsx
@@ -94,7 +94,12 @@ class APSWebManager extends Component {
      * @param message The received message.
      */
     messageHandler( message: {} ) {
-        this.logger.debug( `>>>>>>>: message: ${JSON.stringify(message)}` );
+        try {
+            this.logger.debug( `>>>>>>>: message: ${JSON.stringify( message )}` );
+        }
+        catch ( e ) {
+            this.logger.error(`Failed to log: ${e}`);
+        }
 
         if (message.aps) {
             switch ( message.aps.type.toLowerCase() ) {


### PR DESCRIPTION
- Fixed APSDate component now handling both mobile with a basic
  <input type="date"/> and computer with a more advanced DayPicker
  component. There seem to be no standard in component events for
  external components like DayPicker which delivers an event that
  looks like a string, can be treated as a string, but typeof says
  object, and console.log(event) shows a string. In any case it
  just delivers its value directly while base HTML components
  deliver value in event.target.value. The events delivered on
  the bus follows a standard format that all components obey.

  On iOS you get 3 scrollers for day, month, and year. Changing
  any of these 3 triggers an event. "Finished" button triggers none!