### PR TITLE
aps-140 Add webb support for React.js

### DIFF
--- a/APS-Webs/APSWebManager/buildInfo.json
+++ b/APS-Webs/APSWebManager/buildInfo.json
@@ -1,3 +1,3 @@
 {
-    "buildNumber": 542
+    "buildNumber": 571
 }

--- a/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/APSVertxEventBusRouter.js
+++ b/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/APSVertxEventBusRouter.js
@@ -94,13 +94,12 @@ export default class APSVertxEventBusRouter implements APSEventBusRouter {
 
         this.sendMsgs = [];
 
-        // Unfortunately this is needed since we cannot receive when the bus is down.
-        this.keepAlive = setInterval( () => {
-            this.message( { routing: { outgoing: `${EVENT_ROUTES.BACKEND}` } }, {
-                aps: { type: "keep-alive" },
-                content: {}
-            } );
-        }, 20000 );
+        // this.keepAlive = setInterval( () => {
+        //     this.message( { routing: { outgoing: `${EVENT_ROUTES.BACKEND}` } }, {
+        //         aps: { type: "keep-alive" },
+        //         content: {}
+        //     } );
+        // }, 20000 );
     }
 
     onBusClose(e) {

--- a/APS-Webs/APSWebManager/src/main/resources/guijson/gui.json
+++ b/APS-Webs/APSWebManager/src/main/resources/guijson/gui.json
@@ -52,11 +52,11 @@
     },
     {
       "id": "num",
-      "name": "numeric-spinner",
+      "name": "numeric",
       "type": "aps-number",
-      "min": 0,
-      "max": 10,
-      "value": 2,
+      "min": 0.0,
+      "max": 10.0,
+      "value": 2.5,
       "headers": {
         "routing": {
           "outgoing": "client",


### PR DESCRIPTION
- Completely redone APSNumber. Is not an extension of APSTextField,
  but only allowing "0123456789,.-" filtering away anything else.
  Have an optional min and max value. No buttons to increase or
  decrease value. However supports > and < for that. This also
  forces a placeholder of "0".
- Commented out the keep alive block for now in APSVertxEventBusRouter.