### PR TITLE
aps-140 Add webb support for React.js

### DIFF
--- a/APS-Webs/APSWebManager/buildInfo.json
+++ b/APS-Webs/APSWebManager/buildInfo.json
@@ -1,3 +1,3 @@
 {
-    "buildNumber": 571
+    "buildNumber": 582
 }

--- a/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/components/APSTextArea.jsx
+++ b/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/components/APSTextArea.jsx
@@ -85,6 +85,7 @@ export default class APSTextArea extends APSComponent {
 
         // noinspection HtmlUnknownAttribute
         return <FormControl componentClass="textarea"
+                            type={"textarea"}
                             value={this.state.value}
                             id={this.props.guiProps.id}
                             rows={this.props.guiProps.rows}

--- a/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/components/APSTextField.jsx
+++ b/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/components/APSTextField.jsx
@@ -18,7 +18,7 @@ import { FormControl, FormGroup } from 'react-bootstrap'
  * A greyed out placeholder for the component.
  *
  */
-class APSTextField extends APSComponent {
+export default class APSTextField extends APSComponent {
 
     constructor( props: {} ) {
         super( props );
@@ -88,6 +88,7 @@ class APSTextField extends APSComponent {
         }
         return <FormGroup id={this.props.guiProps.id + '_fg'} validationState={this.state.validationState}>
             <FormControl componentClass="input"
+                         type={""}
                          value={this.state.value}
                          id={this.props.guiProps.id}
                          placeholder={placeHolder}
@@ -98,5 +99,4 @@ class APSTextField extends APSComponent {
     }
 }
 
-// noinspection JSUnusedGlobalSymbols
-export default APSTextField;
+

--- a/APS-Webs/APSWebManager/src/main/resources/guijson/gui.json
+++ b/APS-Webs/APSWebManager/src/main/resources/guijson/gui.json
@@ -54,7 +54,7 @@
       "id": "num",
       "name": "numeric",
       "type": "aps-number",
-      "min": 0.0,
+      "min": -10.0,
       "max": 10.0,
       "value": 2.5,
       "headers": {


### PR DESCRIPTION
- Fixed the last bug in APSNumber and made the code a bit cleaner.
- Did try to use <input type="number" .../> instead but that worked
  worse than my textfield based component om OSX, and not at all on
  iOS and Android. Mine does not have buttons for upp and down, but
  it validates input as you write and it is impossible to enter
  invalid numbers.