### PR TITLE
aps-140 Add webb support for React.js

### DIFF
--- a/APS-Webs/APSWebManager/buildInfo.json
+++ b/APS-Webs/APSWebManager/buildInfo.json
@@ -1,3 +1,3 @@
 {
-    "buildNumber": 630
+    "buildNumber": 638
 }

--- a/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/APSVertxEventBusRouter.js
+++ b/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/APSVertxEventBusRouter.js
@@ -222,8 +222,6 @@ export default class APSVertxEventBusRouter implements APSEventBusRouter {
             // this._logger.debug("CALLBACK: " + callback);
 
             if ( typeof message !== "undefined" ) {
-                // For some reason we get the full internal vertx eventbus message, not just
-                // the client relevant 'body' part.
                 callback( message['body'] );
             }
             else {

--- a/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/App.js
+++ b/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/App.js
@@ -6,7 +6,7 @@ class App extends Component {
   render() {
     return (
       <div className="App">
-        <APSWebManager name={"default"}/>
+        <APSWebManager app={"demo"} name={"default"}/>
       </div>
     );
   }

--- a/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/components/APSTextArea.jsx
+++ b/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/components/APSTextArea.jsx
@@ -74,7 +74,7 @@ export default class APSTextArea extends APSComponent {
     }
 
     componentDidMount() {
-        this.sendDefaultValue();
+
     }
 
     render() {

--- a/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/components/APSTextField.jsx
+++ b/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/components/APSTextField.jsx
@@ -32,8 +32,6 @@ export default class APSTextField extends APSComponent {
             validationState: ""
         };
 
-        this.empty = true;
-
     }
 
     componentType(): string {
@@ -77,7 +75,7 @@ export default class APSTextField extends APSComponent {
     }
 
     componentDidMount() {
-        this.sendDefaultValue();
+
     }
 
     render() {

--- a/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/components/APSWebManager.jsx
+++ b/APS-Webs/APSWebManager/src/main/js/aps-webmanager-frontend/src/components/APSWebManager.jsx
@@ -53,11 +53,26 @@ export default class APSWebManager extends Component {
         };
 
         this.busAddress = new APSBusAddress( APP_NAME );
+
+        this.apsEventBus = APSEventBus.createBus( this.props.name, this.busAddress );
+        this.logger.debug(`APSEventBus: ${this.apsEventBus}`);
     }
 
     //
     // Component Interactions
     //
+
+    getApp() {
+        let app;
+        if (this.props.guiProps && this.props.guiProps.app) {
+            app = this.props.guiProps.app;
+        }
+        else {
+            app = this.props.app;
+        }
+
+        return app;
+    }
 
     /**
      * React callback for when component is available.
@@ -84,7 +99,7 @@ export default class APSWebManager extends Component {
             message: {
                 aps: {
                     origin: this.busAddress.client,
-                    app: "aps-web-manager",
+                    app: this.getApp(),
                     type: "avail"
                 }
             }
@@ -166,6 +181,24 @@ export default class APSWebManager extends Component {
             gui: gui,
             comps: this.parseGui( gui, { key: 0 } )
         } );
+
+        // Tell all created components that all are created.
+        this.apsEventBus.message({
+            headers: {
+                routing: {
+                    incoming: "none",
+                    outgoing: "client"
+                }
+            },
+            message: {
+                aps: {
+                    origin: this.busAddress.client,
+                    app: this.getApp(),
+                    type: "gui-created"
+                },
+                content: {}
+            }
+        });
     }
 
     /**

--- a/APS-Webs/APSWebManager/src/main/resources/guijson/gui.json
+++ b/APS-Webs/APSWebManager/src/main/resources/guijson/gui.json
@@ -26,7 +26,7 @@
       "headers": {
         "routing": {
           "outgoing": "client",
-          "incoming": "none"
+          "incoming": "client"
         }
       }
     },
@@ -41,7 +41,7 @@
       "headers": {
         "routing": {
           "outgoing": "client",
-          "incoming": "none"
+          "incoming": "client"
         }
       }
     },
@@ -57,7 +57,7 @@
       "enabled": "groupNotEmpty:gpoc",
       "headers": {
         "routing": {
-          "outgoing": "client,backend",
+          "outgoing": "backend",
           "incoming": "client"
         }
       }
@@ -72,7 +72,7 @@
       "headers": {
         "routing": {
           "outgoing": "client",
-          "incoming": "none"
+          "incoming": "client"
         }
       }
     },
@@ -97,7 +97,7 @@
       "headers": {
         "routing": {
           "outgoing": "client",
-          "incoming": "none"
+          "incoming": "client"
         }
       }
     }


### PR DESCRIPTION
- Smartified which failed due to a previous stupidify, but worked
  when the stupidity were removed.

  Anyhow the following is now happening:
    When a new GUI has been fully created by APSWebManager it sends
    a "gui-created" message. This triggers components to send their
    default start value. This has the effect that "collector" components
    that listen to other components and save their values actually gets
    a start value.

    This is useful for, for example a submit button part of a group that
    collects values of other components in the group and wants to be
    disabled until all other group components have a non empty value.

    This also follows the principle of only listening to information
    provided, not needing to request it first. The sending out of
    default values does not break this.